### PR TITLE
Change check for needed upload_file workaround to use file's basename

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2483,7 +2483,7 @@ sub upload_file {
     #WORKAROUND: Since this is undocumented selenium functionality,
     #work around a bug.
     my ($drive, $path, $file) = File::Spec::Functions::splitpath($ret);
-    if ($file ne $filename) {
+    if ($file ne basename($filename)) {
         $ret = File::Spec::Functions::catpath($drive,$path,$filename);
     }
 


### PR DESCRIPTION
Try this out and see if your issue is still fixed.  I have a feeling this check might future-proof things a bit.
