### PR TITLE
Remove workaround code, see if Zip 'Name' header obviates it

### DIFF
--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2449,7 +2449,7 @@ sub button_up {
 
     When passing raw data, be advised that it expects a zipped
     and then base64 encoded version of a single file.
-    Multiple files are not supported by the remote server.
+    Multiple files and/or directories are not supported by the remote server.
 
  Usage:
     my $remote_fname = $driver->upload_file( $fname );

--- a/lib/Selenium/Remote/Driver.pm
+++ b/lib/Selenium/Remote/Driver.pm
@@ -2479,13 +2479,6 @@ sub upload_file {
     my $res = { 'command' => 'uploadFile' };    # /session/:SessionId/file
     my $ret = $self->_execute_command( $res, $params );
 
-    #WORKAROUND: Since this is undocumented selenium functionality,
-    #work around a bug.
-    my ($drive, $path, $file) = File::Spec::Functions::splitpath($ret);
-    if (defined $raw_content && $file ne $filename) {
-        $ret = File::Spec::Functions::catpath($drive,$path,$filename);
-    }
-
     return $ret;
 }
 


### PR DESCRIPTION
Test this out with a real Selenium head and see how it works out.
